### PR TITLE
Add functionality to send in jsx as label in selects

### DIFF
--- a/src/utils/optionizer.js
+++ b/src/utils/optionizer.js
@@ -1,4 +1,3 @@
-/* @flow */
 /**
  * So, the select options come in all sorts of shapes and sizes
  * and the role of this module is to normalize all this madness
@@ -26,7 +25,13 @@
 import React from 'react';
 import type { InputProps, SelectOption, Component } from '../types';
 
-type LabelValueOption = SelectOption;
+type JSXElement = {
+  $$typeof: Symbol
+};
+
+type LabelValueOption = SelectOption & {
+  label: string | JSXElement
+};
 type NamedOption = { name: string, disabled?: boolean };
 type StringOption = string;
 type NumberOption = number;
@@ -48,6 +53,8 @@ type StateProps = {
   options: Array<LabelValueOption>
 };
 
+const isJSX = label => label && typeof label === 'object' && label.$$typeof !== undefined;
+
 export default () => (Input: Component) =>
   class Optionizer extends React.Component<OptionizedProps, StateProps> {
     state = { options: [] };
@@ -68,7 +75,7 @@ export default () => (Input: Component) =>
       return this.normalizedOptions(props).map((option, index) => {
         if (
           typeof option === 'object' &&
-          typeof option.label === 'string' &&
+          (typeof option.label === 'string' || isJSX(option.label)) &&
           typeof option.value === 'string'
         ) {
           return { label: option.label, value: option.value, disabled: option.disabled };

--- a/test/inputs/select_test.js
+++ b/test/inputs/select_test.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Fragment } from 'react';
 import { spy } from 'sinon';
 import { mount } from 'enzyme';
 import { Select } from '../../src';
@@ -58,6 +58,17 @@ describe('<Select />', () => {
     });
 
     expect(onChange).to.have.been.calledWith(options[1]);
+  });
+
+  it('allows jsx labels', () => {
+    const options = [
+      { label: <Fragment>cat</Fragment>, value: 'cat' },
+      { label: <Fragment>dog</Fragment>, value: 'dog' }
+    ];
+    const render = mount(<Select layout={null} options={options} />);
+    expect(render.html()).to.eql(
+      '<select><option value="cat">cat</option><option value="dog">dog</option></select>'
+    );
   });
 
   it('allows key -> value options', () => {


### PR DESCRIPTION
When sending in options to select it converts them all to `{label: string, value: string}`. This adds an extra check when you're sending a label/value pair to see if the label is jsx and does not convert it into a string.