### PR TITLE
apply className to layout not input

### DIFF
--- a/src/core/layout.js
+++ b/src/core/layout.js
@@ -25,7 +25,7 @@ export default class LayoutHandler extends React.Component<HandlerProps> {
    * an input receives all the props except the layout ones
    */
   inputProps(): Object {
-    const { props: { label, layout, ...rest } } = this.props; // eslint-disable-line
+    const { props: { className, label, layout, ...rest } } = this.props; // eslint-disable-line
     return rest;
   }
 
@@ -35,7 +35,7 @@ export default class LayoutHandler extends React.Component<HandlerProps> {
    * the class name goes into the input field by default
    */
   layoutProps(): Object {
-    const { props: { id, className, ...rest }, error, dirty } = this.props; // eslint-disable-line
+    const { props: { id, ...rest }, error, dirty } = this.props; // eslint-disable-line
     return { ...rest, error: dirty === false ? null : error };
   }
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -31,6 +31,7 @@ declare module 'a-plus-forms' {
     input: InputProps
     label?: string
     error?: string
+    className?: string
   }
 
   export type Options = any[] | object;

--- a/test/core/field_test.js
+++ b/test/core/field_test.js
@@ -64,11 +64,6 @@ describe('field', () => {
       expect(render.html()).to.eql('<div><div><input id="my-input" value=""></div></div>');
     });
 
-    it('renders #className param', () => {
-      const render = mount(<Input className="my-class" />);
-      expect(render.html()).to.eql('<div><div><input class="my-class" value=""></div></div>');
-    });
-
     it('renders #placeholder param', () => {
       const render = mount(<Input placeholder="My Value" />);
       expect(render.html()).to.eql('<div><div><input placeholder="My Value" value=""></div></div>');

--- a/test/core/layout_test.js
+++ b/test/core/layout_test.js
@@ -5,12 +5,13 @@ import type { InputProps, Element } from '../../src/types';
 
 class Layout1 extends React.Component {
   props: {
+    className: string,
     input: Element
   };
 
   render() {
     return (
-      <div>
+      <div className={this.props.className}>
         <s>Layout1</s>
         {this.props.input}
       </div>
@@ -47,6 +48,11 @@ describe('layouts handling', () => {
   it('allows to specify another layout', () => {
     const render = mount(<Input label="Some label" layout={Layout2} />);
     expect(render.html()).to.eql('<div><s>Layout2</s><input value=""></div>');
+  });
+
+  it('applies className to the layout', () => {
+    const render = mount(<Input className="some-class" />);
+    expect(render.html()).to.eql('<div class="some-class"><s>Layout1</s><input value=""></div>');
   });
 
   it('allows to disable a layout', () => {


### PR DESCRIPTION
This PR makes a change so that when className is provided to field, it's applied to the layout rather than input.