### PR TITLE
Rework defaultValue overrides from form wrapper.

### DIFF
--- a/src/core/field.js
+++ b/src/core/field.js
@@ -83,7 +83,9 @@ export default (options: FieldOptions = {}) => (Input: Component): Component => 
         this.stateManager.setValue(props.value, triggerOnChange);
       } else if ('defaultValue' in props) {
         // something was changed or an initial call
-        if (isInitialCall || this.props.defaultValue !== props.defaultValue) {
+        if (isInitialCall) {
+          this.stateManager.setValue(this.value || props.defaultValue, triggerOnChange);
+        } else if (this.props.defaultValue !== props.defaultValue) {
           this.stateManager.setValue(props.defaultValue, triggerOnChange);
         }
       }

--- a/src/core/field.js
+++ b/src/core/field.js
@@ -84,7 +84,11 @@ export default (options: FieldOptions = {}) => (Input: Component): Component => 
       } else if ('defaultValue' in props) {
         // something was changed or an initial call
         if (isInitialCall) {
-          this.stateManager.setValue(this.value || props.defaultValue, triggerOnChange);
+          // if field has an initial value set (even falsy ones) use it. otherwise default
+          this.stateManager.setValue(
+            this.value !== undefined ? this.value : props.defaultValue,
+            triggerOnChange
+          );
         } else if (this.props.defaultValue !== props.defaultValue) {
           this.stateManager.setValue(props.defaultValue, triggerOnChange);
         }

--- a/test/core/form_test.js
+++ b/test/core/form_test.js
@@ -123,6 +123,18 @@ describe('<Form />', () => {
     expect(render.at(0).instance().value).to.eql(values);
   });
 
+  it('even if those values are falsy', () => {
+    const values = { username: null, password: '' };
+    const render = mount(
+      <Form defaultValue={values}>
+        <TextInput name="username" defaultValue="droo" />
+        <PasswordInput name="password" />
+      </Form>
+    );
+
+    expect(render.at(0).instance().value).to.eql(values);
+  });
+
   it('allows to reset the form values back to the defaults', () => {
     const defaultValues = { username: 'nikolay', password: 'secret' };
     const render = mount(

--- a/test/core/form_test.js
+++ b/test/core/form_test.js
@@ -121,6 +121,7 @@ describe('<Form />', () => {
     );
 
     expect(render.at(0).instance().value).to.eql(values);
+    expect(render.find('input[type="text"]').instance().value).to.eql('nikolay');
   });
 
   it('even if those values are falsy', () => {

--- a/test/core/form_test.js
+++ b/test/core/form_test.js
@@ -111,6 +111,18 @@ describe('<Form />', () => {
     });
   });
 
+  it('toplevel initial values have priority over lower ones', () => {
+    const values = { username: 'nikolay', password: 'secret' };
+    const render = mount(
+      <Form defaultValue={values}>
+        <TextInput name="username" defaultValue="droo" />
+        <PasswordInput name="password" />
+      </Form>
+    );
+
+    expect(render.at(0).instance().value).to.eql(values);
+  });
+
   it('allows to reset the form values back to the defaults', () => {
     const defaultValues = { username: 'nikolay', password: 'secret' };
     const render = mount(


### PR DESCRIPTION
Higher level default values should very likely override their lower-level compatriates. That way lower level components like inputs can store a default, and that default will be replaced by a higher-order form's default values; ones likely read out of a db someplace.