### PR TITLE
pass all props to null layout and always use layout

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -35,7 +35,7 @@ const FormLayout = ({ error, input }: LayoutProps) =>
 const NullLayout = ({ input, error }: NullLayoutProps) => (
   <React.Fragment>
     {input}
-    <small className="error">{error}</small>
+    {error ? <small className="error">{error}</small> : null}
   </React.Fragment>
 );
 

--- a/src/core/layout.js
+++ b/src/core/layout.js
@@ -45,9 +45,9 @@ export default class LayoutHandler extends React.Component<HandlerProps> {
     const { APFLayout } = this.context;
 
     if ('layout' in props) {
-      return props.layout || null; // individual props layout
+      return props.layout || config.NullLayout; // individual props layout
     } else if (layout !== undefined) {
-      return layout || null; // the field options layout
+      return layout || config.NullLayout; // the field options layout
     } else if (APFLayout) {
       return APFLayout; // the context layout
     }
@@ -59,14 +59,6 @@ export default class LayoutHandler extends React.Component<HandlerProps> {
     const { input: Input } = this.props;
     const input = <Input {...this.inputProps()} />;
     const Layout = this.chooseLayout();
-
-    if (!Layout) {
-      if (this.props.error) {
-        return <config.NullLayout input={input} error={this.props.error} />;
-      }
-
-      return input;
-    }
 
     return <Layout {...this.layoutProps()} input={input} />;
   }

--- a/test/core/layout_test.js
+++ b/test/core/layout_test.js
@@ -69,6 +69,16 @@ describe('layouts handling', () => {
     expect(render).to.have.descendants('small.error');
   });
 
+  it('passes layout props to null layout', () => {
+    const render = mount(<Input className="some-class" layout={null} />);
+
+    expect(render)
+      .to.have.exactly(1)
+      .descendants('NullLayout');
+
+    expect(render.find('NullLayout')).to.include.props({ className: 'some-class' });
+  });
+
   it('renders the options layout as the next in kin', () => {
     const render = mount(<Input />);
     expect(render.html()).to.eql('<div><s>Layout1</s><input value=""></div>');


### PR DESCRIPTION
This PR ensures that all layout props are passed to the null layout, this is because a custom NullLayout may be used which makes use of other props, i.e. if using styled components you may need the className prop.

As part of this I've changed it so that the NullLayout is always used, it never just renders the input on its own, but it now conditionally renders the error in the NullLayout.