### PR TITLE
Add test case for onchange bug

### DIFF
--- a/test/core/field_test.js
+++ b/test/core/field_test.js
@@ -264,6 +264,30 @@ describe('field', () => {
       );
     });
 
+    it('propagates changes across inputs with values in onChange', () => {
+      const AcrossInputs = field({ nested: true })(({ onChange }) => (
+        <div>
+          <TextInput
+            name="username"
+            onChange={username => onChange({ username, password: undefined })}
+          />
+          <PasswordInput name="password" />
+        </div>
+      ));
+
+      const login = { username: 'is terrible', password: 'is weak' };
+
+      const render = mount(
+        <Form defaultValue={{ login }}>
+          <AcrossInputs name="login" />
+        </Form>
+      );
+
+      render.find(TextInput).simulate('change', 'another username');
+
+      expect(render.find(PasswordInput).instance().value).to.eql(undefined);
+    });
+
     it('sends errors to sub-fields', () => {
       const error = { username: 'is terrible', password: 'is weak' };
       const render = mount(<NestedInput error={error} />);


### PR DESCRIPTION
Nested fields do seem propagate value changes to children whose values are set in the parent's `onChange` handler.

This PR has a test case with an example of resetting a field when another is changed.