### PR TITLE
:recycle: relax types on error/label to allow jsx rendering.

### DIFF
--- a/src/core/error.js
+++ b/src/core/error.js
@@ -1,4 +1,5 @@
 /* @flow */
+import { isValidElement } from 'react';
 import type { Element } from '../types';
 
 type Errors = Object | string;
@@ -44,9 +45,11 @@ export class ErrorsManager {
     return propsError == null ? APFError[name] : propsError; // eslint-disable-line
   }
 
-  getErrorMessage(): ?string {
+  getErrorMessage(): ?string | Error {
     const { fieldOptions: options } = this.element.constructor;
     const error = this.getCurrentError();
+
+    if (isValidElement(error)) return error;
 
     if (error != null && typeof error !== 'string') { // eslint-disable-line
       let nestedErrors = error;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -17,7 +17,7 @@ declare module 'a-plus-forms' {
     name?: string,
     help?: string,
     error?: string | any,
-    label?: string,
+    label?: string | any,
     value?: any,
     defaultValue?: any,
     className?: string,
@@ -30,8 +30,8 @@ declare module 'a-plus-forms' {
 
   export type LayoutProps = {
     input: InputProps,
-    label?: string,
-    error?: string
+    label?: string | any,
+    error?: string | any
   }
 
   export type Options = any[] | object;

--- a/src/types.js
+++ b/src/types.js
@@ -69,8 +69,8 @@ export type Element = {
 
 export type LayoutProps = {
   input: any,
-  label?: string,
-  error?: string
+  label?: any,
+  error?: any
 };
 
 export type Validator = {

--- a/test/core/layout_test.js
+++ b/test/core/layout_test.js
@@ -103,4 +103,23 @@ describe('layouts handling', () => {
       '<div><label>Some label</label><div><input type="text" value=""></div></div>'
     );
   });
+
+  it('default allows rendering anything as label/error', () => {
+    const render = mount(
+      <TextInput
+        label={<strong>Really helpful</strong>}
+        error={
+          <ul>
+            <li>lots</li>
+          </ul>
+        }
+      />
+    );
+    expect(render)
+      .to.have.exactly(1)
+      .descendants('DefaultLayout');
+    expect(render.html()).to.eql(
+      '<div><label><strong>Really helpful</strong></label><div><input type="text" value=""></div><small><ul><li>lots</li></ul></small></div>'
+    );
+  });
 });


### PR DESCRIPTION
The default layout `label` was already able to render JSX instead of just text, but the types for it were restrictive.

I relaxed the typing on that, and also changed the error renamer slightly so that it too could render JSX if you so desired.