### PR TITLE
allow setting a default defaultValue within field

### DIFF
--- a/src/core/field.js
+++ b/src/core/field.js
@@ -95,6 +95,15 @@ export default (options: FieldOptions = {}) => (Input: Component): Component => 
         } else if (!isEqual(this.props.defaultValue, props.defaultValue)) {
           this.stateManager.setValue(props.defaultValue, triggerOnChange);
         }
+      } else if ('defaultValue' in options) {
+        // something was changed or an initial call
+        if (isInitialCall) {
+          // if field has an initial value set (even falsy ones) use it. otherwise default
+          this.stateManager.setValue(
+            this.value !== undefined ? this.value : options.defaultValue,
+            triggerOnChange
+          );
+        }
       }
     }
 

--- a/test/core/field_test.js
+++ b/test/core/field_test.js
@@ -104,6 +104,20 @@ describe('field', () => {
     });
   });
 
+  describe('default values', () => {
+    const DefaultedValue = field({ defaultValue: 'a greyt value' })(TextInput);
+
+    it('allows defaulting a value', () => {
+      const render = mount(<DefaultedValue />);
+      expect(render.at(0).instance().value).to.equal('a greyt value');
+    });
+
+    it('allows defaulting a value', () => {
+      const render = mount(<DefaultedValue defaultValue="an amazing value" />);
+      expect(render.at(0).instance().value).to.equal('an amazing value');
+    });
+  });
+
   describe('data flow', () => {
     it('allows to set the current value of the field', () => {
       const render = mount(<Input layout={null} value="Nikolay" />);


### PR DESCRIPTION
This PR allows specifying a defaultValue at the field level. This allows defining a defaultValue that will be used across all instances of that input, but can still be overridden by explicitly passing in a defaultValue per input.