### PR TITLE
add defaultValue to options in type defs

### DIFF
--- a/src/types.js
+++ b/src/types.js
@@ -32,7 +32,8 @@ export type FieldProps = Valuable & {
 export type FieldOptions = {
   layout?: Component | null | false,
   nested?: boolean,
-  array?: boolean
+  array?: boolean,
+  defaultValue?: any
 };
 
 export type InputProps = {


### PR DESCRIPTION
Realised after adding `defaultValue` as an option in field, this was not added to our type definitions. This fixes the the missing type def.