### PR TITLE
:recycle: pass the name/id through to wrapped form.

### DIFF
--- a/src/core/form.js
+++ b/src/core/form.js
@@ -143,11 +143,18 @@ export default class Form extends React.Component<FormProps> {
   };
 
   render() {
-    const { children, defaultValue, className } = this.props;
+    const { children, defaultValue, className, name, id } = this.props;
     const { errors, dirty, disabled } = this.state;
 
     return (
-      <form onSubmit={this.onSubmit} className={className} noValidate disabled={disabled}>
+      <form
+        id={id}
+        name={name}
+        onSubmit={this.onSubmit}
+        className={className}
+        noValidate
+        disabled={disabled}
+      >
         <StateContainer
           dirty={dirty}
           error={errors}

--- a/src/types.js
+++ b/src/types.js
@@ -11,6 +11,7 @@ export type Valuable = {
 };
 
 export type FormProps = Valuable & {
+  id?: String,
   value?: ?Object,
   defaultValue?: ?Object,
   schema: Object | Function,

--- a/test/core/form_test.js
+++ b/test/core/form_test.js
@@ -440,4 +440,16 @@ describe('<Form />', () => {
 
     expect(render.find(TextInput).instance().value).to.eql('antikolay');
   });
+
+  it('passses name and id to the underlying form element', () => {
+    const render = mount(
+      <Form name="that-form" id="that-form-niner">
+        <TextInput name="username" />
+        <PasswordInput name="password" />
+      </Form>
+    );
+
+    expect(render.find('form')).to.include.html(' name="that-form"');
+    expect(render.find('form')).to.include.html(' id="that-form-niner"');
+  });
 });


### PR DESCRIPTION
turns out, forms would accept a name prop, but would nullify it if passed one.

It can be very useful to allow forms to be given an ID and a name. We might need this if we ever start doing A/B testing.