### PR TITLE
Fix radios

### DIFF
--- a/src/core/state.js
+++ b/src/core/state.js
@@ -1,5 +1,6 @@
 /* @flow */
 /* eslint no-use-before-define: off */
+import isEqual from 'fast-deep-equal';
 import type { Element } from '../types';
 
 type Field = Element & {
@@ -10,6 +11,7 @@ type Field = Element & {
 
 export default class StateManager {
   element: Field;
+
   currentValue: any;
 
   constructor(element: Field) {
@@ -34,7 +36,7 @@ export default class StateManager {
       const index = parent.getIndexFor(this.element);
       const parentValue = parent.getValue() || [];
 
-      if (parentValue[index] !== value) {
+      if (!isEqual(parentValue[index], value)) {
         if (propagate) onChange(value);
         const newValue = [...parentValue.slice(0, index), value, ...parentValue.slice(index + 1)];
         parent.setValue(Object.freeze(newValue), propagate);
@@ -53,7 +55,8 @@ export default class StateManager {
     if (parent !== undefined && name !== undefined) {
       const parentValue = parent.getValue() || {};
       return parentValue[name];
-    } else if (parent !== undefined && parent.isArray) {
+    }
+    if (parent !== undefined && parent.isArray) {
       const index = parent.getIndexFor(this.element);
       const value = parent.getValue() || [];
       return value[index];
@@ -63,6 +66,7 @@ export default class StateManager {
   }
 
   listFields: Array<Field> = [];
+
   register(field: Field) {
     const { name } = field.props;
     const currentValue: Object = this.getValue() || {};
@@ -94,7 +98,9 @@ export default class StateManager {
   }
 
   get isArray(): boolean {
-    const { constructor: { fieldOptions: options } } = this.element;
+    const {
+      constructor: { fieldOptions: options }
+    } = this.element;
 
     return options.array === true;
   }

--- a/src/inputs/radios.js
+++ b/src/inputs/radios.js
@@ -19,7 +19,7 @@ export default class Radios extends React.Component<RadiosProps> {
     const { value: currentValue, options = [], name, ...rest } = this.props;
 
     return (
-      <div>
+      <div data-label={name}>
         {options.map(({ label, value, disabled }, i) => {
           const id = Math.random()
             .toString(16)

--- a/src/inputs/radios.js
+++ b/src/inputs/radios.js
@@ -31,7 +31,6 @@ export default class Radios extends React.Component<RadiosProps> {
                 {...rest}
                 id={id}
                 type="radio"
-                name={name}
                 value={value}
                 onChange={this.onChange}
                 checked={value === currentValue}

--- a/test/inputs/radios_test.js
+++ b/test/inputs/radios_test.js
@@ -31,6 +31,17 @@ describe('<Radios />', () => {
     expect(labelFor[1]).to.eql(inputFor[1]);
   });
 
+  it('understands the `name` prop', () => {
+    const render = mount(<Radios layout={null} options={options} name="size" />);
+
+    expect(stripIdAndFor(render.html())).to.eql(
+      '<div data-label="size">' +
+        '<label><input type="radio" value="one"><span>One</span></label>' +
+        '<label><input type="radio" value="two"><span>Two</span></label>' +
+        '</div>'
+    );
+  });
+
   it('doesnt explode without options', () => {
     const render = mount(<Radios layout={null} />);
     expect(render.html()).to.eql('<div></div>');

--- a/test/inputs/radios_test.js
+++ b/test/inputs/radios_test.js
@@ -31,17 +31,6 @@ describe('<Radios />', () => {
     expect(labelFor[1]).to.eql(inputFor[1]);
   });
 
-  it('understands the `name` prop', () => {
-    const render = mount(<Radios layout={null} options={options} name="size" />);
-
-    expect(stripIdAndFor(render.html())).to.eql(
-      '<div>' +
-        '<label><input type="radio" name="size" value="one"><span>One</span></label>' +
-        '<label><input type="radio" name="size" value="two"><span>Two</span></label>' +
-        '</div>'
-    );
-  });
-
   it('doesnt explode without options', () => {
     const render = mount(<Radios layout={null} />);
     expect(render.html()).to.eql('<div></div>');


### PR DESCRIPTION
Drew and I discovered a bug with the a-plus-forms radios component. If you have multiple radios inside the same form with the same name, the standard html behaviour takes over and only allows you to select one radio across ALL of the radio buttons. This is a problem because it is valid to have multiple `Radios` with the same name, i.e. when you use an array field, that renders radios (inside a nested field). 

The simplest solution seems to be to remove the `name` property from radios as I don't think we need this. This removes the standard HTML behaviour of changing which radios are selected. Applying a unique name to the radios is not really possible as it depends on the grouping, and this would then be a different name to what we submit to the server in any case.

Also found another issue where array fields are using `!==` to see if the value has changed, but this doesn't cater for them receiving nested fields, where the value is an object and so this has been updated to use fast deep equals.